### PR TITLE
Feedback

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "extends": ["standard"],
+  "rules":
+    {
+      "comma-dangle": [2, "always-multiline"],
+      "no-unused-vars": [2, {"vars": "all", "varsIgnorePattern": "^_"}]
+    }
+}

--- a/src/meta.js
+++ b/src/meta.js
@@ -1,0 +1,2 @@
+export const module = () =>
+export const fn = () =>

--- a/src/msg-reader.js
+++ b/src/msg-reader.js
@@ -1,0 +1,69 @@
+import assert from 'assert'
+import meta from './meta'
+
+meta.module(module, {
+  doc: `
+    # Binary message reader
+
+    Example message:
+
+        4b 00 00 00 0c 00 00 84 03 48 65 fb 75
+        ^  ^---------^ ^---------------------^
+        header  |                |
+              length            body
+
+    The length field includes itself, so a message with a single body byte will have a length of 5.
+
+    The byte format of: 1 byte header, 4 byte length, N byte body
+
+    Gets transformed to the JS record:
+
+      { head: Buffer <single header byte>, body: Buffer <body bytes> }
+
+    So the example above would be:
+
+     msg record: { head: Buffer <4b>, body: Buffer <00 00 84 03 48 65 fb 75> }
+  `,
+})
+
+// -
+
+meta.fn('read', {
+  doc: 'Attempt to read the first message from a given buffer',
+  shape: 'Buffer, int?, int? -> [ { head: Buffer, body: Buffer }?, Buffer ]',
+  args: [
+    'buffer with msg data in it, required',
+    'size of header, defaults to 1',
+    'size of length bytes, defaults to 4',
+    'whether the message length include the length bytes, defaults to true',
+  ],
+  returns: [
+    'message record, will be null if no message could be read from buffer',
+    'overflow bytes from buffer',
+  ],
+  examples: {
+    '1 byte header, 4 byte length field, 1 byte body, 1 byte overflow': (f) => {
+      const hexBuf = (...args) => new Buffer(args.split(' ').map((s) => parseInt(s, 16)))
+      const [{head, body}, over] = f(hexBuf('0a 00 00 00 01 0b 0c'), 1, 4)
+      assert.deepEqual(head, hexBuf('0a'))
+      assert.deepEqual(body, hexBuf('0b'))
+      assert.deepEqual(over, hexBuf('0c'))
+    },
+  },
+})
+
+export const read = (buf, headLength = 1, lengthBytesCount = 4, lengthBytesInclusive = true) => {
+  const headStart = 0
+  const headEnd = headStart + headLength
+  const lengthStart = headEnd
+  const lengthEnd = headEnd + lengthBytesCount
+  const bodyStart = lengthEnd
+  const lengthBytes = buf.slice(lengthStart, lengthEnd)
+  const bodyLength = lengthBytes.readUInt32BE() - (lengthBytesInclusive ? lengthBytesCount : 0)
+  const bodyEnd = bodyStart + bodyLength
+  if (/* buf is incomplete message */ bodyEnd > buf.length) return [ null, buf ]
+  return [ {
+    head: buf.slice(headStart, headEnd),
+    body: buf.slice(bodyStart, bodyEnd),
+  }, buf.slice(bodyEnd) ]
+}

--- a/supported-data-types.md
+++ b/supported-data-types.md
@@ -1,0 +1,44 @@
+# Supported Postgres Data Types
+
+| Name                             | Aliases                          | Desc                                | PG OID    | Supported |
+| ---------------------------------|----------------------------------| ------------------------------------| ----------|----------|
+| bigint                           | int8                             | signed eight-byte integer           | 20        | No        |
+| bigserial                        | serial8                          | autoincrementing eight-byte integer | [20]      | No        |
+| bit [ (n) ]                      |                                  | fixed-length bit string             | 1560      | No        |
+| bit varying [ (n) ]              | varbit                           | variable-length bit string          | 1562      | No        |
+| boolean                          | bool                             | logical Boolean (true/false)        | 16        | No        |
+| bytea                            |                                  | binary data ("byte array")          | 17        | No        |
+| character [ (n) ]                | char [ (n) ]                     | fixed-length character string       | 18        | No        |
+| character varying [ (n) ]        | varchar [ (n) ]                  | variable-length character string    | 1043      | No        |
+| cidr                             |                                  | IPv4 or IPv6 network address        | 650       | No        |
+| circle                           |                                  | circle on a plane                   | 718       | No        |
+| date                             |                                  | calendar date (year, month, day)    | 1082      | No        |
+| double precision                 |                                  | double precision float (8 bytes)    | 701       | No        |
+| inet                             |                                  | IPv4 or IPv6 host address           | 869       | No        |
+| integer                          |                                  | signed four-byte integer            | 23        | No        |
+| interval                         |                                  | time span                           | 1186      | No        |
+| json                             |                                  | textual JSON data                   | 114       | No        |
+| jsonb                            |                                  | binary JSON data, decomposed        | 3802      | No        |
+| line                             |                                  | infinite line on a plane            | 628       | No        |
+| lseg                             |                                  | line segment on a plane             | 601       | No        |
+| macaddr                          |                                  | MAC (Media Access Control) address  | 829       | No        |
+| money                            |                                  | currency amount                     | 790       | No        |
+| numeric                          | decimal [ (p, s) ]               | exact numeric of selectable pre.    | 1700      | No        |
+| path                             |                                  | geometric path on a plane           | 602       | No        |
+| pg_lsn                           |                                  | PostgreSQL Log Sequence Number      | 3220      | No        |
+| point                            |                                  | geometric point on a plane          | 600       | No        |
+| polygon                          |                                  | closed geometric path on a plane    | 604       | No        |
+| real                             | float4                           | single precision float (4 bytes)    | 700       | No        |
+| smallint                         | int2                             | signed two-byte integer             | 21        | No        |
+| smallserial                      | serial2                          | autoincrementing two-byte integer   | [21]      | No        |
+| serial                           | serial4                          | autoincrementing two-byte integer   | [21]      | No        |
+| text                             |                                  | variable-length character string    | 25        | No        |
+| time [ (p) ] [ without tz ]      |                                  | time of day (no time zone)          | 1083      | No        |
+| time [ (p) ] with tz             | timetz                           | time of day, including time zone    | 1266      | No        |
+| timestamp [ (p) ] [ without tz ] |                                  | date and time (no time zone)        | 1114      | No        |
+| timestamp [ (p) ] with tz        | timestamptz                      | date and time, including time zone  | 1184      | No        |
+| tsquery                          |                                  | text search query                   | 3615      | No        |
+| tsvector                         |                                  | text search document                | 3614      | No        |
+| txid_snapshot                    |                                  | user-level transaction ID snapshot  | 2970      | No        |
+| uuid                             |                                  | universally unique identifier       | 2950      | No        |
+| xml                              |                                  | XML data                            | 142       | No        |


### PR DESCRIPTION
I've added some more commentary to the README about the planned direction.

But the main thing in this commit is the example `msg-reader.js` module. This is an evolution on the `vf` idea, which I agree with you did't feel right. But the `pg-message-parser.js` also felt like a bad precedent to set for the rest of the project's modules.

I took the approach of going "documentation-first" or "documentation-driven", breaking the documentation up into specific fields like `shape`, `args`, `examples` etc and what fell out was one function that captures the requirements of the 6 functions in `pg-message-parser.js` (unless I'm mistaken).

I'm not saying that "one is better than 6" (because it's usually not) but that if we emphasize _description_ of every sub-problem in a fairly rigorous way then small implementations are likely to "fall out". We'll still need separate test files to cover corner cases and capture regression cases, but I do think including usage examples above the implementations source - even if those usage examples are never run, as is the case here - is a good idea simply because it gives the reader another "hook" for understanding what the code they're looking at does.  
